### PR TITLE
[EPO-793] First attempt at auto-running cells.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  INotebookTracker
+  INotebookTracker,
+  NotebookActions
 } from '@jupyterlab/notebook';
 
 /**
@@ -50,10 +51,16 @@ const extension: JupyterLabPlugin<void> = {
         if (tracker.currentWidget.notebook.activeCell.model.metadata.get("hideCode") == "true") {
           app.commands.execute('notebook:hide-cell-code');
         } 
-        else if (tracker.currentWidget.notebook.activeCell.model.metadata.get("readOnly") == "true") {
+        if (tracker.currentWidget.notebook.activeCell.model.metadata.get("readOnly") == "true") {
           // sets CSS pointer-events to none and cursor to default to make cell read only. 
           tracker.currentWidget.notebook.activeCell.node.style.pointerEvents = "none";
           tracker.currentWidget.notebook.activeCell.node.style.cursor = "default";
+        }
+        if (tracker.currentWidget.notebook.activeCell.model.metadata.get("autoRun") == "true") {
+          // NotebookActions.run will run the currently active cell, so this is implictly using
+          // the activeCellIndex to pick which cell to run in the notebook.  The session refers
+          // to which python kernel to use to run the cell.
+          NotebookActions.run(tracker.currentWidget.notebook, tracker.currentWidget.session);
         }
         tracker.currentWidget.notebook.activeCellIndex++;
       }     


### PR DESCRIPTION
If you mark a cell as autoRun: true, now it will run on loading of
the notebook.

I've taken out the hook to rerun on change, because if you switch
between two notebooks then the code will be re-run (eliminating
answers put into answer boxes, and selections on graphs).

I've also elimited the else, because sometimes we want to hide the
code, have the code be read only, and have the code run automatically.